### PR TITLE
Minor typo

### DIFF
--- a/app/src/main/res/values/strings-donottranslate.xml
+++ b/app/src/main/res/values/strings-donottranslate.xml
@@ -88,7 +88,7 @@
     <string name="identifier_british_library"
             translatable="false">The British Library</string>
     <string name="identifier_dnb"
-            translatable="false">Deutschen Nationalbibliothek</string>
+            translatable="false">Deutsche Nationalbibliothek</string>
     <string name="identifier_doi"
             translatable="false">Digital Object Identifier</string>
     <string name="identifier_douban"


### PR DESCRIPTION
…the remaining uses of the string are ok (“Deutsche Nationalbibliothek” → “Katalog der Deutschen Nationalbibliothek”).